### PR TITLE
Remove crwriter, improvement on SetHistoryFile behavior: not on non terminal, return errors

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -65,7 +65,10 @@ func Main() int {
 	defer t.Close()
 	t.SetPrompt("Terminal demo> ")
 	t.LoggerSetup()
-	t.SetHistoryFile(*flagHistory)
+	if err := t.SetHistoryFile(*flagHistory); err != nil {
+		// error already logged
+		return 1
+	}
 	fmt.Fprintf(t.Out, "Terminal is open\nis valid %t\nuse exit or ^D or ^C to exit\n", t.IsTerminal())
 	fmt.Fprintf(t.Out, "Use 'prompt <new prompt>' to change the prompt\n")
 	fmt.Fprintf(t.Out, "Try 'after duration text...' to see text showing in the middle of edits after said duration\n")

--- a/terminal_test.go
+++ b/terminal_test.go
@@ -1,52 +1,17 @@
 package terminal_test
 
 import (
-	"strings"
 	"testing"
 
 	"fortio.org/terminal"
 )
 
-type testCRWriter struct {
-	count   int
-	builder strings.Builder
-}
+// Darth test - your lack of testing is disturbing
 
-func (t *testCRWriter) Write(p []byte) (n int, err error) {
-	t.count++
-	return t.builder.Write(p)
-}
-
-func TestCRWriter_Write(t *testing.T) {
-	tests := []struct {
-		input     string
-		want      string
-		numWrites int
-	}{
-		{"Hello, World!", "Hello, World!", 1}, // no \n only 1 write
-		{"", "", 0},                           // empty string, no write
-		{"\n", "\r\n", 1},                     // 1 \n optimized to 1 write "at the end"
-		{"Hello, World!\n", "Hello, World!\r\n", 1},
-		{"Hello,\nWorld!\nNo last newline", "Hello,\r\nWorld!\r\nNo last newline", 1},
-		{"\nHello, World!\n", "\r\nHello, World!\r\n", 1},
-		{"Hello, World!\n\t", "Hello, World!\r\n\t", 1},
-	}
-	for _, tt := range tests {
-		out := testCRWriter{}
-		w := &terminal.CRWriter{Out: &out}
-		n, err := w.Write([]byte(tt.input))
-		if err != nil {
-			t.Errorf("CRWriter.Write(%q) error = %v, want nil", tt.input, err)
-		}
-		if n != len(tt.input) {
-			t.Errorf("CRWriter.Write(%q) = %v, want %v", tt.input, n, len(tt.input))
-		}
-		if out.count != tt.numWrites {
-			t.Errorf("CRWriter.Write(%q) = %v writes, want %v", tt.input, out.count, tt.numWrites)
-		}
-		actual := out.builder.String()
-		if actual != tt.want {
-			t.Errorf("CRWriter.Write(%q) = %q, want %q", tt.input, actual, tt.want)
-		}
+func TestSetHistoryFile(t *testing.T) {
+	term := terminal.Terminal{}
+	err := term.SetHistoryFile("/a/b/c")
+	if err != nil {
+		t.Errorf("as we run tests without terminal, history file should be ignored/no error: %v", err)
 	}
 }


### PR DESCRIPTION
- move crwriter to https://github.com/ldemailly/go-scratch/tree/main/crwriter
- improve history file api
- add ... 1 test (replacing the crwriter only tests now gone)
