### PR TITLE
Add interrupt detection and Ctrl-C handling/filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ See the godoc above for details.
 
 The [grol](https://github.com/grol-io/grol#grol) command line repl and others use this.
 
-The implementations currently is a wrapper fully encapsulating (our fork of) [x/term](https://github.com/golang/term), i.e. [fortio.org/term](https://github.com/fortio/term)
+The implementations currently is a wrapper fully encapsulating (our fork of) [x/term](https://github.com/golang/term), i.e. [fortio.org/term](https://github.com/fortio/term) and new features like the interrupts handling (filters Ctrl-C ahead of term' reads)

--- a/example/main.go
+++ b/example/main.go
@@ -1,3 +1,7 @@
+/*
+ * A more interesting/real example is https://github.com/grol-io/grol
+ * but this demonstrates most of the features of the terminal package.
+ */
 package main
 
 import (

--- a/example/main.go
+++ b/example/main.go
@@ -122,7 +122,7 @@ func Main() int { //nolint:funlen // long but simple (and some amount of copy pa
 				log.Infof("Triple interrupt, exiting.")
 				return 0
 			}
-			log.Infof("Interrupted (%d), resetting, use exit or Ctrl-d. to exit.", interrupts)
+			log.Infof("Interrupted (%d), resetting, use exit or ^D. to exit.", interrupts)
 			ctx, cancel = t.ResetInterrupts(context.Background()) //nolint:fatcontext // this is only upon interrupt.
 		default:
 			return log.FErrf("Error reading line: %v", err)

--- a/interrupt.go
+++ b/interrupt.go
@@ -1,0 +1,122 @@
+package terminal
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
+
+	"fortio.org/log"
+)
+
+type InterruptReader struct {
+	reader  io.Reader // stdin typically
+	buf     []byte
+	bufSize int
+	err     error
+	mu      sync.Mutex
+	cancel  context.CancelFunc
+}
+
+var ErrInterrupted = errors.New("terminal interrupted")
+
+// NewInterruptReader creates a new interrupt reader.
+// it needs to be Start()ed to start reading from the underlying reader
+// and intercept Ctrl-C and listen for interrupt signals.
+func NewInterruptReader(reader io.Reader, bufSize int) *InterruptReader {
+	ir := &InterruptReader{
+		reader:  reader,
+		bufSize: bufSize,
+		buf:     make([]byte, 0, bufSize),
+	}
+	log.Config.GoroutineID = true
+	return ir
+}
+
+// Start or restart (after a cancel/interrupt) the interrupt reader.
+func (ir *InterruptReader) Start(ctx context.Context) (context.Context, context.CancelFunc) {
+	ir.mu.Lock()
+	defer ir.mu.Unlock()
+	if ir.cancel != nil {
+		ir.cancel()
+	}
+	nctx, cancel := context.WithCancel(ctx)
+	ir.cancel = cancel
+	go func() {
+		ir.start(nctx)
+	}()
+	return nctx, cancel
+}
+
+// Implement io.Reader interface.
+func (ir *InterruptReader) Read(p []byte) (int, error) {
+	ir.mu.Lock()
+	n := copy(p, ir.buf)
+	ir.buf = ir.buf[n:]
+	err := ir.err
+	ir.err = nil
+	ir.mu.Unlock()
+	return n, err
+}
+
+const CtrlC = 3
+
+func (ir *InterruptReader) start(ctx context.Context) {
+	localBuf := make([]byte, ir.bufSize)
+	sigc := make(chan os.Signal, 1)
+	signal.Notify(sigc, os.Interrupt, syscall.SIGTERM)
+
+	for {
+		select {
+		case <-sigc:
+			log.Infof("Interrupted by signal")
+			ir.cancel()
+			ir.mu.Lock()
+			ir.err = ErrInterrupted
+			ir.mu.Unlock()
+			return
+		case <-ctx.Done():
+			log.Infof("Context done")
+			ir.mu.Lock()
+			ir.err = ErrInterrupted
+			ir.mu.Unlock()
+			return
+		default:
+			n, err := ir.reader.Read(localBuf)
+			if err != nil {
+				ir.mu.Lock()
+				ir.err = err
+				ir.mu.Unlock()
+				return
+			}
+			localBuf = localBuf[:n]
+			idx := bytes.IndexByte(localBuf, CtrlC)
+			if idx != -1 {
+				log.Infof("Ctrl-C found in input")
+				localBuf = localBuf[:idx] // discard ^c and the rest.
+				ir.cancel()
+			}
+			ir.mu.Lock()
+			ir.buf = append(ir.buf, localBuf...) // Might grow unbounded if not read.
+			ir.mu.Unlock()
+		}
+	}
+}
+
+
+
+func SleepWithContext(ctx context.Context, duration time.Duration) error {
+	select {
+	case <-time.After(duration):
+		// Completed the sleep duration
+		return nil
+	case <-ctx.Done():
+		// Context was canceled
+		return ctx.Err()
+	}
+}

--- a/terminal.go
+++ b/terminal.go
@@ -37,7 +37,7 @@ type Terminal struct {
 // New cancellable context is returned, use it to cancel the terminal
 // reading or check for done for control-c or signal.
 func Open(ctx context.Context) (t *Terminal, err error) {
-	intrReader := NewInterruptReader(os.Stdin, 256)
+	intrReader := NewInterruptReader(os.Stdin, 256) // same as the internal x/term buffer size.
 	rw := struct {
 		io.Reader
 		io.Writer

--- a/terminal.go
+++ b/terminal.go
@@ -248,7 +248,8 @@ func (t *Terminal) Close() error {
 
 // ReadLine reads a line from the terminal using the setup prompt and history
 // and edit capabilities. Returns the line and an error if any. io.EOF is returned
-// when the user presses ^D or ^C.
+// when the user presses Control-D. ErrInterrupted is returned when the user presses
+// Control-C or a signal is received.
 func (t *Terminal) ReadLine() (string, error) {
 	c, err := t.term.ReadLine()
 	// That error isn't an error that needs to be propagated,


### PR DESCRIPTION
See example - but basically allows to interrupt the sleep command for instance (will be used in grol to interrupt long running scripts)


```go
$ go run ./example
11:01:34.002 r1 [INF] Loaded 9 history entries from .history
Terminal is open
is valid true
use exit or ^D or 3 ^C to exit
Use 'prompt <new prompt>' to change the prompt
Try 'after duration text...' to see text showing in the middle of edits after said duration
Try <tab> for auto completion
Terminal demo> after 5s a message
11:01:50.502 r1 [INF] Read line got: "after 5s a message"
11:01:50.502 r1 [INF] Will show "a message" after 5s
Terminal demo> sleep 10s
11:01:53.078 r1 [INF] Read line got: "sleep 10s"
11:01:53.078 r1 [INF] Sleeping for 10s (^C to interrupt)
a message
11:01:56.592 r3 [INF] Ctrl-C found in input
11:01:56.592 r3 [INF] Context done
11:01:56.592 r1 [INF] Sleep interrupted: context canceled
11:01:56.592 r1 [INF] Interrupted, resetting, use exit or Ctrl-d. to exit.
Terminal demo> 
```