### PR TITLE
Added `terminal.UpdateSize()` and calling it during `terminal.Open()` in order to have correct line wrapping

### DIFF
--- a/ansipixels/ansipixels.go
+++ b/ansipixels/ansipixels.go
@@ -1,4 +1,5 @@
-// ansipixel provides terminal drawing and key reading abilities. fps/fps.go and life/life.go are examples/demos of how to use it.
+// ansipixels provides terminal drawing and key reading abilities.
+// [fortio.org/terminal/fps] and life/life.go are examples/demos of how to use it.
 package ansipixels
 
 import (

--- a/terminal.go
+++ b/terminal.go
@@ -69,7 +69,7 @@ func Open(ctx context.Context) (t *Terminal, err error) {
 	return
 }
 
-// Refreshes the terminal size to current size (so wrapping works).
+// UpdateSize refreshes the terminal size to current size (so wrapping works).
 // This is called automatically when the terminal is opened, but can be called
 // again if the terminal size changes (e.g. when resizing the window).
 func (t *Terminal) UpdateSize() error {


### PR DESCRIPTION
Fixes #87