### PR TITLE
Handle the case where the input is not terminal. x/term.ReadLine hangs until \r, do it ourselves allowing either \r, \n or \r\n

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@ tinygo-demo:
 
 test:
 	CGO_ENABLED=0 go test -tags $(GO_BUILD_TAGS) ./...
-	(echo -e "help\rafter 1s hi\r"; sleep 2) | go run -race -tags $(GO_BUILD_TAGS) ./example -loglevel debug # check non terminal input
+	(printf "help\rafter 1s hi\r\n"; sleep 2; printf "after 1s 2nd\nprompt new \r"; sleep 2) | \
+		go run -race -tags $(GO_BUILD_TAGS) ./example -loglevel debug # check non terminal input
 
 lint: .golangci.yml
 	CGO_ENABLED=0 golangci-lint run --build-tags $(GO_BUILD_TAGS)

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ tinygo-demo:
 
 test:
 	CGO_ENABLED=0 go test -tags $(GO_BUILD_TAGS) ./...
-	(printf "help\rafter 1s hi\r\n"; sleep 2; printf "after 1s 2nd\nprompt new \r"; sleep 2) | \
+	(printf "hel"; sleep 1 ; printf "p\rafter 1s hi\r\n"; sleep 2; printf "after 1s 2nd\nprompt new \r"; sleep 2) | \
 		go run -race -tags $(GO_BUILD_TAGS) ./example -loglevel debug # check non terminal input
 
 lint: .golangci.yml

--- a/interrupt.go
+++ b/interrupt.go
@@ -156,11 +156,14 @@ func (ir *InterruptReader) ReadNonBlocking(p []byte) (int, error) {
 // It returns the line (without the \r, \n, or \r\n).
 func (ir *InterruptReader) ReadLine() (string, error) {
 	needAtLeast := 0
+	ir.mu.Lock()
 	for {
-		ir.mu.Lock()
-		for len(ir.buf) < needAtLeast && ir.err == nil {
+		// log.Debugf("ReadLine before loop for input %d", needAtLeast)
+		for len(ir.buf) <= needAtLeast && ir.err == nil {
+			// log.Debugf("ReadLine waiting for input %d", needAtLeast)
 			ir.cond.Wait()
 		}
+		// log.Debugf("ReadLine after loop for input %d, %v", len(ir.buf), ir.err)
 		err := ir.err
 		line := ""
 		for i, c := range ir.buf {
@@ -197,7 +200,6 @@ func (ir *InterruptReader) ReadLine() (string, error) {
 			ir.mu.Unlock()
 			return line, err
 		}
-		ir.mu.Unlock()
 	}
 }
 

--- a/interrupt.go
+++ b/interrupt.go
@@ -152,8 +152,8 @@ func (ir *InterruptReader) ReadNonBlocking(p []byte) (int, error) {
 	return n, err
 }
 
-// ReadLine reads until \r and/or \n (for use when not in rawmode)
-// and return the line (without the \r nor \n nor \r\n).
+// ReadLine reads until \r or \n (for use when not in rawmode).
+// It returns the line (without the \r, \n, or \r\n).
 func (ir *InterruptReader) ReadLine() (string, error) {
 	needAtLeast := 0
 	for {

--- a/terminal.go
+++ b/terminal.go
@@ -334,7 +334,7 @@ func (t *Terminal) Close() error {
 // x/term.ReadLine unfortunately doesn't support \n, so we need to handle that ourselves.
 func (t *Terminal) ReadLine() (string, error) {
 	if !t.IntrReader.Raw() {
-		_, _ = t.Out.Write([]byte(t.lastPrompt))
+		_, _ = t.Out.Write(t.lastPrompt)
 		return t.IntrReader.ReadLine()
 	}
 	c, err := t.term.ReadLine()

--- a/terminal.go
+++ b/terminal.go
@@ -39,7 +39,8 @@ type Terminal struct {
 	// Terminal (last updated) width.
 	Width int
 	// Terminal (last updated) height.
-	Height int
+	Height     int
+	lastPrompt []byte
 }
 
 // Open opens stdin as a terminal, do `defer terminal.Close()`
@@ -329,7 +330,13 @@ func (t *Terminal) Close() error {
 // and edit capabilities. Returns the line and an error if any. io.EOF is returned
 // when the user presses Control-D. ErrInterrupted is returned when the user presses
 // Control-C or a signal is received.
+// We forward to term.ReadLine when in raw mode, otherwise we read until \n or \r.
+// x/term.ReadLine unfortunately doesn't support \n, so we need to handle that ourselves.
 func (t *Terminal) ReadLine() (string, error) {
+	if !t.IntrReader.Raw() {
+		_, _ = t.Out.Write([]byte(t.lastPrompt))
+		return t.IntrReader.ReadLine()
+	}
 	c, err := t.term.ReadLine()
 	// If Ctrl-D generated a synthetic EOF, we need to close the interrupt reader.
 	if errors.Is(err, io.EOF) && !t.IntrReader.InEOF() {
@@ -348,6 +355,7 @@ func (t *Terminal) ReadLine() (string, error) {
 
 // Sets or change the prompt.
 func (t *Terminal) SetPrompt(s string) {
+	t.lastPrompt = []byte(s)
 	t.term.SetPrompt(s)
 }
 


### PR DESCRIPTION
Arguably a bug in x/term but lets address it here

- [x] testing with grol, one bug/pause during startup while changing loglevel

bug / hang in grol had to do with starting the terminal thread before executing the long parsing of a large .gr state: needs change from https://github.com/grol-io/grol/pull/369 yet it seems brittle


