### PR TITLE
don't turn on bracketed paste mode by default, expose the option (because of LF, see comments)

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -82,6 +82,7 @@ func Main() int { //nolint:funlen // long but simple (and some amount of copy pa
 	flagHistory := flag.String("history", ".history", "History `file` to use")
 	flagMaxHistory := flag.Int("max-history", 10, "Max number of history lines to keep")
 	flagOnlyValid := flag.Bool("only-valid", false, "Demonstrates filtering of history, only adding valid commands to it")
+	flagBracketedPaste := flag.Bool("bracketed-paste", false, "Enable bracketed paste mode")
 	cli.Main()
 	t, err := terminal.Open(context.Background())
 	if err != nil {
@@ -91,6 +92,10 @@ func Main() int { //nolint:funlen // long but simple (and some amount of copy pa
 		t.Close()
 		log.Infof("Terminal closed/restored")
 	}()
+	if *flagBracketedPaste {
+		t.SetBracketedPasteMode(true)
+		log.Infof("Bracketed paste mode enabled")
+	}
 	onlyValid := *flagOnlyValid
 	if onlyValid {
 		t.SetAutoHistory(false)

--- a/terminal.go
+++ b/terminal.go
@@ -82,12 +82,23 @@ func (t *Terminal) Setup(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	t.term.SetBracketedPasteMode(true) // Seems useful to have it on by default.
 	t.capacity = DefaultHistoryCapacity
 	LoggerSetup(t.Out)
 	err = t.UpdateSize() // error already logged - tbd to return or not / not fatal
 	t.ResetInterrupts(ctx)
 	return err
+}
+
+// SetBracketedPasteMode enables or disables bracketed paste mode.
+// Non bracketed means each new line in what is paste will be returning a new command.
+// Bracketed paste mode means that the pasted text is treated as a single command but
+// with several terminal emulators, as raw LineFeed (LF) so 3 lines show as 1 command.
+//
+//	line1
+//	      line2
+//	            line3
+func (t *Terminal) SetBracketedPasteMode(enabled bool) {
+	t.term.SetBracketedPasteMode(enabled)
 }
 
 // UpdateSize refreshes the terminal size to current size (so wrapping works).


### PR DESCRIPTION
So this "fixes" #124 because ghostty somewhat correctly sends verbatim \n (LF) in bracketed paste mode (vs \r from apple terminal and iterm2)

but it has this fairly big downside when pasting `line one\n` one gets:
```
16:29:18.089 r1 [VRB] AutoCompleteCallback: "" 0 'l'
16:29:18.089 r1 [VRB] AutoCompleteCallback: "l" 1 'i'
16:29:18.090 r1 [VRB] AutoCompleteCallback: "li" 2 'n'
16:29:18.090 r1 [VRB] AutoCompleteCallback: "lin" 3 'e'
16:29:18.090 r1 [VRB] AutoCompleteCallback: "line" 4 ' '
16:29:18.090 r1 [VRB] AutoCompleteCallback: "line " 5 'o'
16:29:18.090 r1 [VRB] AutoCompleteCallback: "line o" 6 'n'
16:29:18.090 r1 [VRB] AutoCompleteCallback: "line on" 7 'e'
Terminal demo> line one
```
