### PR TITLE
Clarify/fix that ReadCursorPos returned row,col,err in 1,1 native terminal coordinates; Adding ReadCursorPosXY returning x,y in 0,0 ansipixels coordinate.

### DIFF
--- a/ansipixels/ansipixels.go
+++ b/ansipixels/ansipixels.go
@@ -331,8 +331,11 @@ func (ap *AnsiPixels) ClearEndOfLine() {
 
 var cursPosRegexp = regexp.MustCompile(`^(.*)\033\[(\d+);(\d+)R(.*)$`)
 
-// This is the same as ReadCursorPos but returns the x,y coordinates
-// with 0,0 origin system.
+// ReadCursorPosXY returns the current X,Y coordinates of the cursor or insertion point
+// using the same coordinate system as MoveCursor, WriteAt, etc. ie 0,0 is the top left corner.
+// it also synchronizes the display and ends the syncmode.
+// It replaces the original/lower level [ReadCursorPos] which returns 1,1 based coordinates
+// and x/y swapped (row, col terminal native coordinates).
 func (ap *AnsiPixels) ReadCursorPosXY() (int, int, error) {
 	row, col, err := ap.ReadCursorPos()
 	if err != nil {
@@ -347,7 +350,7 @@ func (ap *AnsiPixels) ReadCursorPosXY() (int, int, error) {
 // It returns row,col (y,x; line and column) and/or an error.
 // It's using the native terminal coordinates which start at 1,1 unlike
 // the AnsiPixels coordinates which start at 0,0.
-// Use ReadCursorPosXY to get 0,0 based coordinates usable with MoveCursor,
+// Use [ReadCursorPosXY] to get 0,0 based coordinates usable with MoveCursor,
 // WriteAt, etc.
 func (ap *AnsiPixels) ReadCursorPos() (int, int, error) {
 	x := -1

--- a/ansipixels/ansipixels.go
+++ b/ansipixels/ansipixels.go
@@ -334,11 +334,11 @@ var cursPosRegexp = regexp.MustCompile(`^(.*)\033\[(\d+);(\d+)R(.*)$`)
 // This is the same as ReadCursorPos but returns the x,y coordinates
 // with 0,0 origin system.
 func (ap *AnsiPixels) ReadCursorPosXY() (int, int, error) {
-	y, x, err := ap.ReadCursorPos()
+	row, col, err := ap.ReadCursorPos()
 	if err != nil {
 		return -1, -1, err
 	}
-	return x - 1, y - 1, nil // convert to 0,0 based coordinates
+	return col - 1, row - 1, nil // convert to 0,0 based coordinates
 }
 
 // ReadCursorPos requests and read native coordinates of the cursor and

--- a/ansipixels/ansipixels.go
+++ b/ansipixels/ansipixels.go
@@ -353,7 +353,7 @@ func (ap *AnsiPixels) ReadCursorPosXY() (int, int, error) {
 // Use [ReadCursorPosXY] to get 0,0 based coordinates usable with MoveCursor,
 // WriteAt, etc.
 //
-//nolint:nakedret // it's really the same return everywhere
+//nolint:nakedret // it's really the same return everywhere with error but the last one.
 func (ap *AnsiPixels) ReadCursorPos() (row int, col int, err error) {
 	col = -1
 	row = -1
@@ -364,7 +364,7 @@ func (ap *AnsiPixels) ReadCursorPos() (row int, col int, err error) {
 		return
 	}
 	if n != len(reqPosStr) {
-		err = fmt.Errorf("short write requesting cursor position: %d", n)
+		err = errors.New("short write")
 		return
 	}
 	err = ap.Out.Flush()

--- a/ansipixels/ansipixels.go
+++ b/ansipixels/ansipixels.go
@@ -334,8 +334,8 @@ var cursPosRegexp = regexp.MustCompile(`^(.*)\033\[(\d+);(\d+)R(.*)$`)
 // ReadCursorPosXY returns the current X,Y coordinates of the cursor or insertion point
 // using the same coordinate system as MoveCursor, WriteAt, etc. ie 0,0 is the top left corner.
 // it also synchronizes the display and ends the syncmode.
-// It replaces the original/lower level [ReadCursorPos] which returns 1,1 based coordinates
-// and x/y swapped (row, col terminal native coordinates).
+// It wraps the original/lower level [ReadCursorPos], which returns 1,1-based coordinates
+// and x/y swapped (row, col terminal native coordinates), and converts them to 0,0-based coordinates.
 func (ap *AnsiPixels) ReadCursorPosXY() (int, int, error) {
 	row, col, err := ap.ReadCursorPos()
 	if err != nil {


### PR DESCRIPTION
Turns out I never used the values outside of error in fps and elsewhere and only when trying in gvi did I step on the issue of flip and different origin
