### PR TITLE
For partial mouse event (try to): get the remainder/missing bytes. Stop consuming all mouse events at once (see MouseDecode doc)

### DIFF
--- a/ansipixels/ansipixels.go
+++ b/ansipixels/ansipixels.go
@@ -411,7 +411,9 @@ func (ap *AnsiPixels) ReadCursorPos() (row int, col int, err error) {
 		ap.Data = append(ap.Data, res[4]...)
 		break
 	}
-	ap.MouseDecode()
+	if !ap.NoDecode {
+		ap.MouseDecode()
+	}
 	return
 }
 

--- a/ansipixels/mouse.go
+++ b/ansipixels/mouse.go
@@ -46,6 +46,15 @@ func (ap *AnsiPixels) MousePixelsOff() {
 
 var mouseDataPrefix = []byte{0x1b, '[', 'M'}
 
+// MouseDecode decodes the mouse data from the AnsiPixels.Data buffer.
+// It us automatically called by ReadOrResizeOrSignal and ReadOrResizeOrSignalOnce unless
+// NoDecode is set to true (so you typically don't need to call it directly and can just
+// check the Mouse, Mx, My, Mbuttons fields).
+// If there is more than one event you can consume them by calling
+//
+//	for ap.MouseDecode() {}
+//
+// (until it returns false, it returns true if there was something decoded).
 func (ap *AnsiPixels) MouseDecode() bool {
 	ap.Mouse = false
 	idx := bytes.Index(ap.Data, mouseDataPrefix)

--- a/ansipixels/mouse.go
+++ b/ansipixels/mouse.go
@@ -63,7 +63,7 @@ func (ap *AnsiPixels) MouseDecode() bool {
 			return false
 		}
 		ap.Data = append(ap.Data, buf[:n]...)
-		if need-n > 0 {
+		if n < need {
 			log.Errf("Not enough bytes read for mouse data: %d, expected %d", n, need)
 			return false
 		}


### PR DESCRIPTION
Also ap.MouseDecode returns a bool directly so to get the previous behavior:
```go
for ap.MouseDecode {}
```

fixes #131 