### PR TITLE
Switch tcolor internal type to uint32 (high 2b is type and 30 bits components) - HSL<->RGB with < 0.2% error roundtrip with 12b Hue, 8b Sat, 10b Lightness; Auto detect color modes; expose ShowScaledImage,...

### DIFF
--- a/ansipixels/image.go
+++ b/ansipixels/image.go
@@ -119,13 +119,13 @@ func (ap *AnsiPixels) DrawMonoImage(sx, sy int, img *image.Gray, color string) e
 	return err
 }
 
-func grayScaleImage(rgbaImg *image.RGBA) *image.Gray {
+func GrayScaleImage(rgbaImg *image.RGBA) *image.Gray {
 	grayImg := image.NewGray(rgbaImg.Bounds())
-	toGrey(rgbaImg, grayImg)
+	ToGray(rgbaImg, grayImg)
 	return grayImg
 }
 
-func toGrey(rgbaImg *image.RGBA, img image.Image) {
+func ToGray(rgbaImg *image.RGBA, img image.Image) {
 	// Iterate through the pixels of the NRGBA image and convert to grayscale
 	for y := rgbaImg.Bounds().Min.Y; y < rgbaImg.Bounds().Max.Y; y++ {
 		for x := rgbaImg.Bounds().Min.X; x < rgbaImg.Bounds().Max.X; x++ {
@@ -271,7 +271,7 @@ func (ap *AnsiPixels) ShowImages(imagesRGBA *Image, zoom float64, offsetX, offse
 // It must already have the right size to fit exactly in width/height within margins.
 func (ap *AnsiPixels) ShowScaledImage(img *image.RGBA) error {
 	if ap.Gray {
-		toGrey(img, img)
+		ToGray(img, img)
 	}
 	var err error
 	switch {
@@ -280,7 +280,7 @@ func (ap *AnsiPixels) ShowScaledImage(img *image.RGBA) error {
 	case ap.Color256:
 		err = ap.Draw216ColorImage(ap.Margin, ap.Margin, img)
 	default:
-		err = ap.DrawMonoImage(ap.Margin, ap.Margin, grayScaleImage(img), ap.MonoColor.Foreground())
+		err = ap.DrawMonoImage(ap.Margin, ap.Margin, GrayScaleImage(img), ap.MonoColor.Foreground())
 	}
 	return err
 }

--- a/ansipixels/tcolor/colors.go
+++ b/ansipixels/tcolor/colors.go
@@ -261,7 +261,7 @@ func FromHSLString(color string) (Color, error) {
 // Initially from grol's image extension.
 func HSLToRGB(h, s, l float64) RGBColor {
 	var r, g, b float64
-	// h = math.Mod(h, 360.) / 360.
+	// h = math.Mod(h, 360.) / 360. if we wanted in degrees.
 	if s == 0 {
 		r, g, b = l, l, l
 	} else {
@@ -300,4 +300,39 @@ func hueToRGB(p, q, t float64) float64 {
 		return p + (q-p)*(2/3.-t)*6
 	}
 	return p
+}
+
+func RGBToHSL(c RGBColor) (h, s, l float64) {
+	r := float64(c.R) / 255.
+	g := float64(c.G) / 255.
+	b := float64(c.B) / 255.
+
+	maxv := max(r, g, b)
+	minv := min(r, g, b)
+	l = (maxv + minv) / 2
+
+	if maxv == minv {
+		h, s = 0, 0 // achromatic
+		return h, s, l
+	}
+	d := maxv - minv
+	if l > 0.5 {
+		s = d / (2 - maxv - minv)
+	} else {
+		s = d / (maxv + minv)
+	}
+
+	switch maxv {
+	case r:
+		h = (g - b) / d
+		if g < b {
+			h += 6
+		}
+	case g:
+		h = (b-r)/d + 2
+	case b:
+		h = (r-g)/d + 4
+	}
+	h /= 6
+	return h, s, l
 }

--- a/ansipixels/tcolor/colors.go
+++ b/ansipixels/tcolor/colors.go
@@ -1,4 +1,10 @@
 // Package tcolor provides ANSI color codes and utilities for terminal colors.
+// You can see a good demo/use of it the tcolor CLI at
+// [github.com/fortio/tcolor](https://github.com/fortio/tcolor) or by running
+// ```shell
+// go install fortio.org/tcolor@latest
+// tcolor
+// ```
 // Initially partially from images.go and tclock and generalized.
 package tcolor // import "fortio.org/terminal/ansipixels/tcolor"
 
@@ -85,31 +91,120 @@ func (c RGBColor) Background() string {
 	return fmt.Sprintf("\033[48;2;%d;%d;%dm", c.R, c.G, c.B)
 }
 
-type Color struct {
-	Basic bool // Selector between BasicColor and RGBColor
-	BasicColor
-	RGBColor
+type Color uint32 // high byte is type, rest is RGB or HSL or BasicColor.
+
+type ColorType uint8 // 0 for RGB, 1 for HSL, 2 for BasicColor
+const (
+	ColorTypeRGB   ColorType = 1 // RGBColor
+	ColorTypeHSL   ColorType = 2 // HSLColor
+	ColorTypeBasic ColorType = 3 // BasicColor
+)
+
+//nolint:gosec // no overflow possible
+func (c Color) Decode() (ColorType, [3]uint8) {
+	u := uint32(c)
+	switch u & 0xFF000000 {
+	case uint32(ColorTypeRGB) << 24:
+		return ColorTypeRGB, [3]uint8{uint8(u >> 16 & 0xFF), uint8(u >> 8 & 0xFF), uint8(u & 0xFF)} // RGB
+	case uint32(ColorTypeHSL) << 24:
+		return ColorTypeHSL, [3]uint8{uint8(u >> 16 & 0xFF), uint8(u >> 8 & 0xFF), uint8(u & 0xFF)} // HSL
+	case uint32(ColorTypeBasic) << 24:
+		return ColorTypeBasic, [3]uint8{uint8(u & 0xFF)}
+	default:
+		panic(fmt.Sprintf("Invalid color type %d", c&0xFF000000))
+	}
+}
+
+func Basic(c BasicColor) Color {
+	return Color(uint32(ColorTypeBasic)<<24 | uint32(c))
+}
+
+func RGB(c RGBColor) Color {
+	return Color(uint32(ColorTypeRGB)<<24 | uint32(c.R)<<16 | uint32(c.G)<<8 | uint32(c.B))
+}
+
+// HSLf creates a Color from HSL float values in [0,1] range.
+func HSLf(h, s, l float64) Color {
+	return Color(uint32(ColorTypeHSL)<<24 |
+		uint32(math.Round(h*255))<<16 | // h in [0,1]
+		uint32(math.Round(s*255))<<8 | // s in [0,1]
+		uint32(math.Round(l*255))) // l in [0,1]
+}
+
+// HSL creates a Color from HSLColor.
+func HSL(hsl HSLColor) Color {
+	return Color(uint32(ColorTypeHSL)<<24 |
+		uint32(hsl.H)<<16 | // h in [0,255]
+		uint32(hsl.S)<<8 | // s in [0,255]
+		uint32(hsl.L)) // l in [0,255]
 }
 
 func (c Color) String() string {
-	if c.Basic {
-		return c.BasicColor.String()
+	t, components := c.Decode()
+	switch t {
+	case ColorTypeRGB:
+		return fmt.Sprintf("#%02X%02X%02X", components[0], components[1], components[2])
+	case ColorTypeHSL:
+		return fmt.Sprintf("HSL_%02X%02X%02X", components[0], components[1], components[2])
+	case ColorTypeBasic:
+		return BasicColor(components[0]).String()
+	default:
+		panic(fmt.Sprintf("Invalid color type %d", t))
 	}
-	return fmt.Sprintf("%02x%02x%02x", c.R, c.G, c.B)
+}
+
+func (c Color) BasicColor() (BasicColor, bool) {
+	t, components := c.Decode()
+	if t == ColorTypeBasic {
+		return BasicColor(components[0]), true
+	}
+	return None, false
+}
+
+func ToRGB(t ColorType, components [3]uint8) RGBColor {
+	switch t {
+	case ColorTypeRGB:
+		return RGBColor{components[0], components[1], components[2]}
+	case ColorTypeHSL:
+		return HSLColor{components[0], components[1], components[2]}.RGB()
+	default:
+		panic(fmt.Sprintf("ToRGB on invalid color type %d", t))
+	}
+}
+
+func ToHSL(t ColorType, components [3]uint8) HSLColor {
+	switch t {
+	case ColorTypeRGB:
+		return RGBColor{components[0], components[1], components[2]}.HSL()
+	case ColorTypeHSL:
+		return HSLColor{components[0], components[1], components[2]}
+	default:
+		panic(fmt.Sprintf("ToHSL on invalid color type %d", t))
+	}
 }
 
 func (c Color) Foreground() string {
-	if c.Basic {
-		return c.BasicColor.Foreground()
+	t, components := c.Decode()
+	switch t {
+	case ColorTypeBasic:
+		return BasicColor(components[0]).Foreground()
+	case ColorTypeRGB, ColorTypeHSL:
+		return ToRGB(t, components).Foreground()
+	default:
+		panic(fmt.Sprintf("Invalid color type %d", t))
 	}
-	return c.RGBColor.Foreground()
 }
 
 func (c Color) Background() string {
-	if c.Basic {
-		return c.BasicColor.Background()
+	t, components := c.Decode()
+	switch t {
+	case ColorTypeBasic:
+		return BasicColor(components[0]).Background()
+	case ColorTypeRGB, ColorTypeHSL:
+		return ToRGB(t, components).Background()
+	default:
+		panic(fmt.Sprintf("Invalid color type %d", t))
 	}
-	return c.RGBColor.Background()
 }
 
 // Ordered list of the basic colors.
@@ -159,6 +254,7 @@ func RGBFromString(color string) (RGBColor, error) {
 }
 
 // FromString converts user input color string to a terminal color.
+// Supports basic color names, RGB hex format (RRGGBB), HSL float format (h,s,l in [0,1]), and HSL hex format (HSL#HHSSLL).
 func FromString(color string) (Color, error) {
 	toRemove := " \t\r\n_-#" // can't remove . because of hsl
 	color = strings.ToLower(strings.Map(func(r rune) rune {
@@ -168,19 +264,22 @@ func FromString(color string) (Color, error) {
 		return r
 	}, color))
 	if c, ok := ColorMap[color]; ok {
-		return Color{Basic: true, BasicColor: c}, nil
+		return Basic(c), nil
 	}
 	if strings.IndexByte(color, ',') != -1 {
-		return FromHSLString(color)
+		return From3floatHSLString(color)
+	}
+	if hex, ok := strings.CutPrefix(color, "hsl"); ok {
+		return FromHexHSLString(hex)
 	}
 	if len(color) == 6 {
 		rgbColor, err := RGBFromString(color)
 		if err != nil {
-			return Color{}, err
+			return 0, err
 		}
-		return Color{Basic: false, RGBColor: rgbColor}, nil
+		return RGB(rgbColor), nil
 	}
-	return Color{}, fmt.Errorf("invalid color '%s', must be RRGGBB or h,s,l or one of: %s", color, ColorHelp)
+	return 0, fmt.Errorf("invalid color '%s', must be RRGGBB or h,s,l or one of: %s", color, ColorHelp)
 }
 
 func RGBATo216(pixel RGBColor) uint8 {
@@ -211,50 +310,99 @@ type ColorOutput struct {
 }
 
 func (co ColorOutput) Foreground(c Color) string {
-	if co.TrueColor || c.Basic {
+	if co.TrueColor {
 		return c.Foreground()
 	}
-	return fmt.Sprintf("\033[38;5;%dm", RGBATo216(c.RGBColor))
+	t, components := c.Decode()
+	switch t {
+	case ColorTypeBasic:
+		return BasicColor(components[0]).Foreground()
+	case ColorTypeRGB, ColorTypeHSL:
+		rgb := ToRGB(t, components)
+		return fmt.Sprintf("\033[38;5;%dm", RGBATo216(rgb))
+	default:
+		panic(fmt.Sprintf("Foreground on invalid color type %d", t))
+	}
 }
 
 func (co ColorOutput) Background(c Color) string {
-	if co.TrueColor || c.Basic {
+	if co.TrueColor {
 		return c.Background()
 	}
-	return fmt.Sprintf("\033[48;5;%dm", RGBATo216(c.RGBColor))
+	t, components := c.Decode()
+	switch t {
+	case ColorTypeBasic:
+		return BasicColor(components[0]).Background()
+	case ColorTypeRGB, ColorTypeHSL:
+		rgb := ToRGB(t, components)
+		return fmt.Sprintf("\033[48;5;%dm", RGBATo216(rgb))
+	default:
+		panic(fmt.Sprintf("Background on invalid color type %d", t))
+	}
 }
 
 // HSL colors.
 
-// FromHSLString converts a string in the format "h,s,l" [0,1] each, to a (rgb) Color.
-func FromHSLString(color string) (Color, error) {
+// HSLColor is the hex version of h,s,l, each in [0,255].
+type HSLColor struct {
+	H, S, L uint8
+}
+
+// FromHSLString converts a string in the format "h,s,l" [0,1] each, to a 3 bytes Color.
+func From3floatHSLString(color string) (Color, error) {
 	parts := strings.SplitN(color, ",", 3)
 	if len(parts) != 3 {
-		return Color{}, fmt.Errorf("invalid HSL color '%s', must be h,s,l", color)
+		return 0, fmt.Errorf("invalid HSL color '%s', must be h,s,l", color)
 	}
 	// H,S,L format
 	h, err := strconv.ParseFloat(parts[0], 64)
 	if err != nil {
-		return Color{}, fmt.Errorf("invalid hue '%s': %w", parts[0], err)
+		return 0, fmt.Errorf("invalid hue '%s': %w", parts[0], err)
 	}
 	if h < 0 || h > 1 {
-		return Color{}, fmt.Errorf("hue must be in [0,1], got %f", h)
+		return 0, fmt.Errorf("hue must be in [0,1], got %f", h)
 	}
 	s, err := strconv.ParseFloat(parts[1], 64)
 	if err != nil {
-		return Color{}, fmt.Errorf("invalid saturation '%s': %w", parts[1], err)
+		return 0, fmt.Errorf("invalid saturation '%s': %w", parts[1], err)
 	}
 	if s < 0 || s > 1 {
-		return Color{}, fmt.Errorf("saturation must be in [0,1], got %f", s)
+		return 0, fmt.Errorf("saturation must be in [0,1], got %f", s)
 	}
 	v, err := strconv.ParseFloat(parts[2], 64)
 	if err != nil {
-		return Color{}, fmt.Errorf("invalid brightness '%s': %w", parts[2], err)
+		return 0, fmt.Errorf("invalid brightness '%s': %w", parts[2], err)
 	}
 	if v < 0 || v > 1 {
-		return Color{}, fmt.Errorf("brightness must be in [0,1], got %f", v)
+		return 0, fmt.Errorf("brightness must be in [0,1], got %f", v)
 	}
-	return Color{RGBColor: HSLToRGB(h, s, v)}, nil
+	return HSLf(h, s, v), nil
+}
+
+// Extract RGB values from a hex color string (HHSSLL) or error.
+// (Same as RGBFromString but bytes being HSL instead of RGB).
+func FromHexHSLString(color string) (Color, error) {
+	var i int
+	_, err := fmt.Sscanf(color, "%x", &i)
+	if err != nil {
+		return 0, fmt.Errorf("invalid HSL hex color '%s', must be hex HHSSLL: %w", color, err)
+	}
+	h := (i >> 16) & 0xFF
+	s := (i >> 8) & 0xFF
+	l := i & 0xFF
+	return HSL(HSLColor{H: uint8(h), S: uint8(s), L: uint8(l)}), nil //nolint:gosec // no overflow here
+}
+
+func (hsl HSLColor) String() string {
+	return fmt.Sprintf("HSL#%02X%02X%02X", hsl.H, hsl.S, hsl.L)
+}
+
+func (hsl HSLColor) RGB() RGBColor {
+	return HSLToRGB(float64(hsl.H)/255., float64(hsl.S)/255., float64(hsl.L)/255.)
+}
+
+func (hsl HSLColor) Color() Color {
+	return HSL(hsl)
 }
 
 // HSLToRGB converts HSL values to RGB. h, s and l in [0,1].
@@ -300,6 +448,19 @@ func hueToRGB(p, q, t float64) float64 {
 		return p + (q-p)*(2/3.-t)*6
 	}
 	return p
+}
+
+func (c RGBColor) HSL() HSLColor {
+	h, s, l := RGBToHSL(c)
+	return HSLColor{
+		H: uint8(math.Round(h * 255)),
+		S: uint8(math.Round(s * 255)),
+		L: uint8(math.Round(l * 255)),
+	}
+}
+
+func (c RGBColor) Color() Color {
+	return RGB(c)
 }
 
 func RGBToHSL(c RGBColor) (h, s, l float64) {

--- a/ansipixels/tcolor/colors.go
+++ b/ansipixels/tcolor/colors.go
@@ -119,7 +119,7 @@ type Uint10 uint16
 
 const (
 	MaxHSLHue        = 4095 // 12 bits
-	MaxHLSSaturation = 255  // 8 bits
+	MaxHSLSaturation = 255  // 8 bits
 	MaxHSLLightness  = 1023 // 10 bits
 )
 
@@ -150,7 +150,7 @@ func RGB(c RGBColor) Color {
 func HSLf(h, s, l float64) Color {
 	return Color(uint32(ColorTypeHSL)<<30 |
 		uint32(math.Round(h*MaxHSLHue))<<18 | // h in [0,1]
-		uint32(math.Round(s*MaxHLSSaturation))<<10 | // s in [0,1]
+		uint32(math.Round(s*MaxHSLSaturation))<<10 | // s in [0,1]
 		uint32(math.Round(l*MaxHSLLightness))) // l in [0,1]
 }
 
@@ -496,7 +496,7 @@ func (hsl HSLColor) String() string {
 }
 
 func (hsl HSLColor) RGB() RGBColor {
-	return HSLToRGB(float64(hsl.H)/MaxHSLHue, float64(hsl.S)/MaxHLSSaturation, float64(hsl.L)/MaxHSLLightness)
+	return HSLToRGB(float64(hsl.H)/MaxHSLHue, float64(hsl.S)/MaxHSLSaturation, float64(hsl.L)/MaxHSLLightness)
 }
 
 func (hsl HSLColor) Color() Color {
@@ -552,7 +552,7 @@ func (c RGBColor) HSL() HSLColor {
 	h, s, l := RGBToHSL(c)
 	return HSLColor{
 		H: Uint12(math.Round(h * MaxHSLHue)),
-		S: Uint8(math.Round(s * MaxHLSSaturation)),
+		S: Uint8(math.Round(s * MaxHSLSaturation)),
 		L: Uint10(math.Round(l * MaxHSLLightness)),
 	}
 }

--- a/ansipixels/tcolor/colors.go
+++ b/ansipixels/tcolor/colors.go
@@ -92,7 +92,7 @@ func (c RGBColor) Background() string {
 }
 
 // Color: high 2 bits is type, rest is RGB or HSL or BasicColor.
-// HSL is 10 bits for each component (H, S, L)
+// HSL is 12 bits for Hue, 8 bits for Saturation, 10 bits for Luminance (lowest error rate when going to/from RGB).
 // RGB is 8 bits for each component (R, G, B).
 type Color uint32
 

--- a/ansipixels/tcolor/colors.go
+++ b/ansipixels/tcolor/colors.go
@@ -92,7 +92,7 @@ func (c RGBColor) Background() string {
 }
 
 // Color: high 2 bits is type, rest is RGB or HSL or BasicColor.
-// HSL is 12 bits for Hue, 8 bits for Saturation, 10 bits for Luminance (lowest error rate when going to/from RGB).
+// HSL is 12 bits for Hue, 8 bits for Saturation, 10 bits for Lightness (lowest error rate when going to/from RGB).
 // RGB is 8 bits for each component (R, G, B).
 type Color uint32
 
@@ -114,7 +114,7 @@ type Uint12 uint16
 // 8 bits for Saturation component in HSL.
 type Uint8 uint8
 
-// 10 bits for Luminance component in HSL.
+// 10 bits for Lightness component in HSL.
 type Uint10 uint16
 
 const (

--- a/ansipixels/tcolor/colors_test.go
+++ b/ansipixels/tcolor/colors_test.go
@@ -55,14 +55,14 @@ func TestParsingAdvancedColor(t *testing.T) {
 		{"#33FF57", tcolor.RGBColor{R: 51, G: 255, B: 87}},
 		{"#3357FF", tcolor.RGBColor{R: 51, G: 87, B: 255}},
 		// HSL are not really verified but seem to make sense (matched what was returned)
-		{"0.5,0.5,0.5", tcolor.RGBColor{R: 64, G: 192, B: 192}},
+		{"0.5,0.5,0.5", tcolor.RGBColor{R: 64, G: 191, B: 192}},
 		{"0.1,1,0.5", tcolor.RGBColor{R: 255, G: 153, B: 0}},
 		{"0.1,1,0.75", tcolor.RGBColor{R: 255, G: 204, B: 127}},
 		{"0.1,1,0.25", tcolor.RGBColor{R: 128, G: 77, B: 0}},
 		{"0.70,0.5,0.5", tcolor.RGBColor{R: 89, G: 64, B: 192}},
-		{"0.75,1,0.5", tcolor.RGBColor{R: 127, G: 0, B: 255}},
-		{"0.75,0.5,0.5", tcolor.RGBColor{R: 127, G: 64, B: 192}},
-		{"1.0,1,0.75", tcolor.RGBColor{R: 255, G: 127, B: 128}},
+		{"0.75,1,0.5", tcolor.RGBColor{R: 128, G: 0, B: 255}},
+		{"0.75,0.5,0.5", tcolor.RGBColor{R: 128, G: 64, B: 192}},
+		{"1.0,1,0.75", tcolor.RGBColor{R: 255, G: 127, B: 127}},
 	}
 	for _, test := range tests {
 		t.Run(test.input, func(t *testing.T) {
@@ -170,9 +170,9 @@ func TestHSLRGBExactRoundTrip3Bytes(t *testing.T) {
 		}
 	}
 	errorPercent := float64(mismatches) / float64(total) * 100
-	t.Logf("Total RGB to HSL roundtrip mismatches: %d out of %d (%.3f%%)",
+	t.Logf("Total RGB to HSL roundtrip mismatches: %d out of %d (%.4f%%)",
 		mismatches, total, errorPercent)
 	if errorPercent > 0.2 { // 0.2% is about what we get
-		t.Fatalf("Total mismatches: %d (%.3f%%)", mismatches, errorPercent)
+		t.Fatalf("Total mismatches: %d (%.4f%%)", mismatches, errorPercent)
 	}
 }

--- a/ansipixels/tcolor/colors_test.go
+++ b/ansipixels/tcolor/colors_test.go
@@ -77,3 +77,27 @@ func TestParsingAdvancedColor(t *testing.T) {
 		})
 	}
 }
+
+func TestHSLRGBExactRoundTrip(t *testing.T) {
+	var mismatches int
+	for r := range 256 {
+		for g := range 256 {
+			for b := range 256 {
+				in := tcolor.RGBColor{uint8(r), uint8(g), uint8(b)}
+				h, s, l := tcolor.RGBToHSL(in)
+				out := tcolor.HSLToRGB(h, s, l)
+
+				if out.R != in.R || out.G != in.G || out.B != in.B {
+					mismatches++
+					if mismatches <= 10 { // log only first few
+						t.Errorf("Mismatch: in=%v hsl=(%.10f,%.10f,%.10f) out=%v",
+							in, h, s, l, out)
+					}
+				}
+			}
+		}
+	}
+	if mismatches > 0 {
+		t.Fatalf("Total mismatches: %d", mismatches)
+	}
+}

--- a/ansipixels/tcolor/colors_test.go
+++ b/ansipixels/tcolor/colors_test.go
@@ -32,12 +32,13 @@ func TestParsingBasicColors(t *testing.T) {
 				t.Errorf("Failed to parse %q: %v", test.input, err)
 				return
 			}
-			if !parsedColor.Basic {
+			bc, ok := parsedColor.BasicColor()
+			if !ok {
 				t.Errorf("Expected basic color for %q, got %#v", test.input, parsedColor)
 				return
 			}
-			if parsedColor.BasicColor != test.expected {
-				t.Errorf("Parsed %q as %d, expected %d", test.input, parsedColor.BasicColor, test.expected)
+			if bc != test.expected {
+				t.Errorf("Parsed %q as %d, expected %d", test.input, bc, test.expected)
 			}
 		})
 	}
@@ -54,11 +55,13 @@ func TestParsingAdvancedColor(t *testing.T) {
 		{"#33FF57", tcolor.RGBColor{R: 51, G: 255, B: 87}},
 		{"#3357FF", tcolor.RGBColor{R: 51, G: 87, B: 255}},
 		// HSL are not really verified but seem to make sense (matched what was returned)
-		{"0.1,1,0.5", tcolor.RGBColor{R: 255, G: 153, B: 0}},
-		{"0.1,1,0.75", tcolor.RGBColor{R: 255, G: 204, B: 128}},
-		{"0.1,1,0.25", tcolor.RGBColor{R: 128, G: 77, B: 0}},
-		{"0.7,1,0.5", tcolor.RGBColor{R: 51, G: 0, B: 255}},
-		{"0.7,0.5,0.5", tcolor.RGBColor{R: 89, G: 64, B: 191}},
+		{"0.5,0.5,0.5", tcolor.RGBColor{R: 64, G: 190, B: 192}},
+		{"0.1,1,0.5", tcolor.RGBColor{R: 255, G: 156, B: 1}},
+		{"0.1,1,0.75", tcolor.RGBColor{R: 255, G: 205, B: 127}},
+		{"0.1,1,0.25", tcolor.RGBColor{R: 128, G: 78, B: 0}},
+		{"0.7,1,0.5", tcolor.RGBColor{R: 55, G: 1, B: 255}},
+		{"0.7,0.5,0.5", tcolor.RGBColor{R: 91, G: 64, B: 192}},
+		{"1.0,1,0.75", tcolor.RGBColor{R: 255, G: 127, B: 127}},
 	}
 	for _, test := range tests {
 		t.Run(test.input, func(t *testing.T) {
@@ -67,12 +70,45 @@ func TestParsingAdvancedColor(t *testing.T) {
 				t.Errorf("Failed to parse %q: %v", test.input, err)
 				return
 			}
-			if parsedColor.Basic {
-				t.Errorf("Expected advanced color for %q, got %#v", test.input, parsedColor)
+			ct, components := parsedColor.Decode()
+			if ct == tcolor.ColorTypeBasic {
+				t.Errorf("Expected advanced color for %q, got %s", test.input, parsedColor.String())
 				return
 			}
-			if parsedColor.RGBColor != test.expected {
-				t.Errorf("Parsed %q as %v, expected %v", test.input, parsedColor.RGBColor, test.expected)
+			rgb := tcolor.ToRGB(ct, components)
+			if rgb != test.expected {
+				t.Errorf("Parsed %q as %s - %v %v -> %v, expected %v", test.input, parsedColor.String(), ct, components, rgb, test.expected)
+			}
+		})
+	}
+}
+
+func TestParsingHSLHex(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected tcolor.HSLColor
+	}{
+		{"HSL#010203", tcolor.HSLColor{H: 1, S: 2, L: 3}},
+		{"HSL#FFFFFF", tcolor.HSLColor{H: 0xFF, S: 0xFF, L: 0xFF}},
+		{"HSL#FF5733", tcolor.HSLColor{H: 0xFF, S: 0x57, L: 0x33}},
+		{"HSL#33FF57", tcolor.HSLColor{H: 0x33, S: 0xFF, L: 0x57}},
+		{"HSL#BEDEAD", tcolor.HSLColor{H: 0xBE, S: 0xDE, L: 0xAD}},
+	}
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			parsedColor, err := tcolor.FromString(test.input)
+			if err != nil {
+				t.Errorf("Failed to parse %q: %v", test.input, err)
+				return
+			}
+			ct, components := parsedColor.Decode()
+			if ct != tcolor.ColorTypeHSL {
+				t.Errorf("Expected advanced color for %q, got %s", test.input, parsedColor.String())
+				return
+			}
+			hsl := tcolor.ToHSL(ct, components)
+			if hsl != test.expected {
+				t.Errorf("Parsed %q as %v, expected %v", test.input, hsl, test.expected)
 			}
 		})
 	}


### PR DESCRIPTION
- Switch color internal type to uint32 (high 2b is type and 30 bits components)
- HSL<->RGB with < 0.2% error roundtrip with 12b Hue, 8b Sat, 10b Lightness
- Auto detect color settings based on NO_COLOR, COLORTERM, and TERM values
- DetectColorMode() can be used before ansi pixel setup for flag defaults.
- Split image showing into ShowImages doing gif animation and scaling vs ShowScaledImage to show a single image of the right size