### PR TITLE
Added `OnMouse` callback. Use the right input reader for further decoding mouse events. Also stop/start sync in animated images

### DIFF
--- a/ansipixels/ansipixels.go
+++ b/ansipixels/ansipixels.go
@@ -58,6 +58,7 @@ type AnsiPixels struct {
 	Margin      int          // Margin around the image (image is smaller by 2*margin)
 	FPS         float64      // (Target) Frames per second used for Reading with timeout
 	OnResize    func() error // Callback when terminal is resized
+	OnMouse     func()       // Callback when mouse event is received
 	// First time we clear the screen, we use 2J to push old content to scrollback buffer, otherwise we use H+0J
 	firstClear bool
 	restored   bool

--- a/ansipixels/image.go
+++ b/ansipixels/image.go
@@ -251,12 +251,17 @@ func (ap *AnsiPixels) ShowImages(imagesRGBA *Image, zoom float64, offsetX, offse
 	// GetSize done in Open and Resize handler.
 	for i, imgRGBA := range imagesRGBA.Images {
 		img := resizeAndCenter(imgRGBA, ap.W-2*ap.Margin, 2*ap.H-4*ap.Margin, zoom, offsetX, offsetY)
+		if i > 0 {
+			ap.StartSyncMode()
+		}
 		err := ap.ShowScaledImage(img)
 		if err != nil {
 			return err
 		}
-		ap.Out.Flush()
 		if i < len(imagesRGBA.Delays)-1 { // maybe read keyboard/signal for stop request in case this is longish.
+			if i > 0 {
+				ap.EndSyncMode()
+			}
 			delay := imagesRGBA.Delays[i]
 			log.Debugf("Delay %d", delay)
 			if delay > 0 {

--- a/ansipixels/mouse.go
+++ b/ansipixels/mouse.go
@@ -81,7 +81,13 @@ func (ap *AnsiPixels) MouseDecode(readMoreIfNeeded bool) MouseStatus {
 		// Read the missing bytes (eg windows terminal sends in 2 chunks).
 		need := start + 3 - len(ap.Data)
 		buf := [3]byte{}
-		n, err := ap.SharedInput.TR.Read(buf[:need])
+		var n int
+		var err error
+		if ap.readSharedMode {
+			n, err = ap.SharedInput.Read(buf[:need])
+		} else {
+			n, err = ap.SharedInput.TR.Read(buf[:need])
+		}
 		if err != nil {
 			log.Errf("Error reading additional mouse data: %v", err)
 			return MouseError
@@ -110,6 +116,8 @@ func (ap *AnsiPixels) MouseDecodeAll() {
 	gotMouse := false
 	for ap.MouseDecode(true) == MouseComplete {
 		// keep decoding mouse events until we have no more.
+		// TODO: consider keeping a list of all the events or saving the left/right clicks in priority
+		// over mouse movements.
 		gotMouse = true
 	}
 	ap.Mouse = gotMouse

--- a/ansipixels/mouse.go
+++ b/ansipixels/mouse.go
@@ -112,6 +112,9 @@ func (ap *AnsiPixels) MouseDecode(readMoreIfNeeded bool) MouseStatus {
 // MouseDecodeAll decodes all mouse events available,
 // useful at low fps where we may have multiple mouse events.
 // Internally used when ap.NoDecode is false.
+// The last event if more than one has been accumulated/sent will win.
+// If you need to keep track of each you can have an OnMouse callback.
+// Or set NoDecode to true and call MouseDecode yourself.
 func (ap *AnsiPixels) MouseDecodeAll() {
 	gotMouse := false
 	for ap.MouseDecode(true) == MouseComplete {
@@ -119,6 +122,9 @@ func (ap *AnsiPixels) MouseDecodeAll() {
 		// TODO: consider keeping a list of all the events or saving the left/right clicks in priority
 		// over mouse movements.
 		gotMouse = true
+		if ap.OnMouse != nil {
+			ap.OnMouse()
+		}
 	}
 	ap.Mouse = gotMouse
 }

--- a/ansipixels/mouse.go
+++ b/ansipixels/mouse.go
@@ -74,7 +74,7 @@ func (ap *AnsiPixels) MouseDecode(readMoreIfNeeded bool) MouseStatus {
 		return NoMouse
 	}
 	start := idx + len(mouseDataPrefix)
-	if start+3 > len(ap.Data) {
+	if start+3 > len(ap.Data) { //nolint:nestif // the 2 possible read sources made this go over.
 		if !readMoreIfNeeded {
 			return MousePrefix
 		}


### PR DESCRIPTION
also fixes leftover missing sync/unsync for animated images

 Fixes #145