### PR TITLE
Bug fix/panic in non truecolor mode for 256 colors

### DIFF
--- a/ansipixels/tcolor/colors.go
+++ b/ansipixels/tcolor/colors.go
@@ -479,8 +479,8 @@ func (co ColorOutput) Background(c Color) string {
 	}
 	t, v := c.Decode()
 	switch t {
-	case ColorTypeBasic:
-		return BasicColor(v).Background() //nolint:gosec // no overflow possible
+	case ColorTypeBasic, ColorType256:
+		return c.Background()
 	case ColorTypeRGB, ColorTypeHSL:
 		rgb := ToRGB(t, v)
 		return fmt.Sprintf("\033[48;5;%dm", RGBATo216(rgb))

--- a/ansipixels/tcolor/colors_test.go
+++ b/ansipixels/tcolor/colors_test.go
@@ -43,6 +43,33 @@ func TestParsingErrors(t *testing.T) {
 	}
 }
 
+func TestWebHSLOut(t *testing.T) {
+	tests := []struct {
+		input      string
+		expected   string
+		background string
+	}{
+		{"c150", "", "\x1b[48;5;150m"},
+	}
+	cOut := tcolor.ColorOutput{TrueColor: false}
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			color, err := tcolor.FromString(test.input)
+			if err != nil {
+				t.Fatalf("Failed to parse %q: %v", test.input, err)
+			}
+			out := tcolor.WebHSL(color, 0)
+			if out != test.expected {
+				t.Errorf("Expected %q, got %q", test.expected, out)
+			}
+			bg := cOut.Background(color)
+			if bg != test.background {
+				t.Errorf("Expected background %q, got %q", test.background, bg)
+			}
+		})
+	}
+}
+
 func TestParsingBasicColors(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/ansipixels/tcolor/colors_test.go
+++ b/ansipixels/tcolor/colors_test.go
@@ -50,6 +50,7 @@ func TestWebHSLOut(t *testing.T) {
 		background string
 	}{
 		{"c150", "", "\x1b[48;5;150m"},
+		{"#F34512", "hsl(14 90 51)", "\x1b[48;5;166m"},
 	}
 	cOut := tcolor.ColorOutput{TrueColor: false}
 	for _, test := range tests {


### PR DESCRIPTION
I had changed Foreground() but not Background() !
Fixes

```
$ tcolor c150
17:00:00.265 [INF] Using 256 colors
17:00:00.265 [INF] Decoding 1 colors mode (pass no argument for interactive)
panic: Background on invalid color type 99

goroutine 1 [running]:
fortio.org/terminal/ansipixels/tcolor.ColorOutput.Background({0xbf?}, 0x1?)
	/Users/dl/go/pkg/mod/fortio.org/terminal@v0.49.0/ansipixels/tcolor/colors.go:488 +0x168
main.decodeColors({0x0?}, 0xffffffffffffffff, {0x14000126090, 0x1, 0x1011d0739?})
	/Users/dl/go/pkg/mod/fortio.org/tcolor@v1.3.0/decode.go:20 +0x158
main.Main()
	/Users/dl/go/pkg/mod/fortio.org/tcolor@v1.3.0/tcolor.go:72 +0x3fc
main.main()
	/Users/dl/go/pkg/mod/fortio.org/tcolor@v1.3.0/tcolor.go:19 +0x1c
```