### PR TITLE
Fill up the WriteBoxed with spaces. Made FPTicks autosync optional. Add new interfaces so logger setup can work and work concurrently

### DIFF
--- a/CRLFWriter.go
+++ b/CRLFWriter.go
@@ -100,3 +100,13 @@ func (w *SyncWriter) WriteRune(r rune) (n int, err error) {
 	w.mu.Unlock()
 	return n, err
 }
+
+// Lock: Shares the underlying lock.
+func (w *SyncWriter) Lock() {
+	w.mu.Lock()
+}
+
+// Unlock: Shares the underlying lock.
+func (w *SyncWriter) Unlock() {
+	w.mu.Unlock()
+}

--- a/ansipixels/ansipixels.go
+++ b/ansipixels/ansipixels.go
@@ -697,15 +697,15 @@ func (ap *AnsiPixels) WriteBoxed(y int, msg string, args ...interface{}) {
 	}
 	var cursorX int
 	var cursorY int
-	x := (ap.W - maxw) / 2
+	leftX := (ap.W - maxw) / 2
 	for i, l := range lines {
 		cursorY = y + i
-		ap.MoveCursor(x, cursorY)
+		ap.MoveCursor(leftX, cursorY)
 		delta := (maxw - widths[i])
 		ap.WriteString(strings.Repeat(" ", delta/2))
 		ap.WriteString(l)
 		ap.WriteString(strings.Repeat(" ", delta/2+delta%2)) // if odd, add 1 more space on the right
-		cursorX = x + delta/2 + widths[i]
+		cursorX = leftX + delta/2 + widths[i]
 	}
 	ap.DrawRoundBox((ap.W-maxw)/2-1, y-1, maxw+2, len(lines)+2)
 	// put back the cursor at the end of the last line (inside the box)

--- a/ansipixels/ansipixels.go
+++ b/ansipixels/ansipixels.go
@@ -78,8 +78,8 @@ type AnsiPixels struct {
 	GotBackground       bool // Whether we got a background color from the terminal (after RequestBackgroundColor and OSCDecode)
 	// Whether to use transparency when drawing truecolor images ([SyncBackgroundColor] needed)
 	Transparency bool
-	// Whether FPSTicks automatically calls StartSyncMode and EndSyncMode around the callback. Note that this prevents the cursor from blinking
-	// at FPS above 4. Default is true.
+	// Whether FPSTicks automatically calls StartSyncMode and EndSyncMode around the callback.
+	// Note that this prevents the cursor from blinking at FPS above 4. Default is true.
 	AutoSync bool
 }
 

--- a/interrupt.go
+++ b/interrupt.go
@@ -317,7 +317,7 @@ func (ir *InterruptReader) start(ctx context.Context) {
 
 func (ir *InterruptReader) setError(err error) {
 	level := log.Info
-	if errors.Is(err, ErrStopped) {
+	if errors.Is(err, ErrStopped) || errors.Is(err, context.Canceled) {
 		level = log.Verbose
 	}
 	log.S(level, "InterruptReader setting error", log.Any("err", err))


### PR DESCRIPTION
- Add CRLFWrite as a function vs just the wrapper type.
- Add Flusher and Bufio interfaces and FlushableByteBuffer fulfilling both
- Add concurrent safe Logger SyncWriter to ap and use it in ap.LoggerSetup()
- Flush the Logger output content during StartSyncMode when AutoSync is on, otherwise do it using
FlushLogger()
- Adding AutoLoggerSetup to automatically do LoggerSetup by default. 
- Purge/send the logger stuff at the end automatically
- Fix #175 don't log info the cancelation of context
